### PR TITLE
p350: Allow to copy gralloc prop

### DIFF
--- a/p350/p350-vendor-blobs.mk
+++ b/p350/p350-vendor-blobs.mk
@@ -21,6 +21,10 @@ PRODUCT_COPY_FILES += \
     vendor/lge/p350/proprietary/lib/hw/lights.pecan.so:system/lib/hw/lights.pecan.so \
     vendor/lge/p350/proprietary/bin/ami304d:system/bin/ami304d \
 
+## HAL
+PRODUCT_COPY_FILES += \
+    vendor/lge/p350/proprietary/lib/hw/gralloc.pecan.so:system/lib/hw/gralloc.pecan.so
+
 # 3D
 PRODUCT_COPY_FILES += \
     vendor/lge/p350/proprietary/lib/egl/libEGL_adreno200.so:system/lib/egl/libEGL_adreno200.so \


### PR DESCRIPTION
this needed because gralloc.pecan.so are not in final zip 
