### PR TITLE
Adding stock d850 APN file with new ATT Nextgenphone APN.

### DIFF
--- a/d850/d850-vendor-blobs.mk
+++ b/d850/d850-vendor-blobs.mk
@@ -70,6 +70,7 @@ PRODUCT_COPY_FILES += \
     vendor/lge/d850/proprietary/vendor/lib/libsensor1.so:system/vendor/lib/libsensor1.so \
     vendor/lge/d850/proprietary/vendor/lib/libsensor_reg.so:system/vendor/lib/libsensor_reg.so \
     vendor/lge/d850/proprietary/etc/apns-conf.xml:system/etc/apns-conf.xml \
+    vendor/lge/d850/proprietary/etc/gps.conf:system/etc/gps.conf \
     vendor/lge/d850/proprietary/etc/firmware/venus.b00:system/etc/firmware/venus.b00 \
     vendor/lge/d850/proprietary/etc/firmware/venus.b01:system/etc/firmware/venus.b01 \
     vendor/lge/d850/proprietary/etc/firmware/venus.b02:system/etc/firmware/venus.b02 \

--- a/d850/d850-vendor-blobs.mk
+++ b/d850/d850-vendor-blobs.mk
@@ -69,6 +69,7 @@ PRODUCT_COPY_FILES += \
     vendor/lge/d850/proprietary/vendor/lib/hw/sensors.msm8974.so:system/vendor/lib/hw/sensors.msm8974.so \
     vendor/lge/d850/proprietary/vendor/lib/libsensor1.so:system/vendor/lib/libsensor1.so \
     vendor/lge/d850/proprietary/vendor/lib/libsensor_reg.so:system/vendor/lib/libsensor_reg.so \
+    vendor/lge/d850/proprietary/etc/apns-conf.xml:system/etc/apns-conf.xml \
     vendor/lge/d850/proprietary/etc/firmware/venus.b00:system/etc/firmware/venus.b00 \
     vendor/lge/d850/proprietary/etc/firmware/venus.b01:system/etc/firmware/venus.b01 \
     vendor/lge/d850/proprietary/etc/firmware/venus.b02:system/etc/firmware/venus.b02 \

--- a/d850/proprietary/etc/apns-conf.xml
+++ b/d850/proprietary/etc/apns-conf.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2006, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<!-- use empty string to specify no proxy or port -->
+
+<!-- If you edit this version, also edit the version in the partner-supplied
+    apns-conf.xml configuration file -->
+<apns version="8">
+
+<!-- ATnT  -->
+
+<apn carrier="ATT Nextgenphone"
+    mcc="310"
+    mnc="410"
+    apn="nxtgenphone"
+    user=""
+    password=""
+    authtype="0"
+    server=""
+    proxy=""
+    port=""
+    mmsc="http://mmsc.mobile.att.net"
+    mmsproxy="proxy.mobile.att.net"
+    mmsport="80"
+    type="default,mms,supl"
+    protocol="IP"
+    preferapp="" />
+
+<apn carrier="ATT Nextgenphone"
+    mcc="310"
+    mnc="410"
+    apn="nxtgenphone"
+    user=""
+    password=""
+    authtype="0"
+    server=""
+    proxy=""
+    port=""
+    mmsc="http://mmsc.mobile.att.net"
+    mmsproxy="proxy.mobile.att.net"
+    mmsport="80"
+    type="xcap"
+    protocol="IP"
+    defaultflag="2"
+    preferapp="" />
+
+<!--
+<apn carrier="ATT Phone"
+    mcc="310"
+    mnc="410"
+    apn="phone"
+    user=""
+    password=""
+    authtype="0"
+    server=""
+    proxy=""
+    port=""
+    mmsc="http://mmsc.mobile.att.net"
+    mmsproxy="proxy.mobile.att.net"
+    mmsport="80"
+    type="default,mms,supl,hipri,fota"
+    protocol="IP"
+    preferapp="" />
+-->
+
+<apn carrier="IMS"
+    mcc="310"
+    mnc="410"
+    apn="ims"
+    user=""
+    password=""
+    authtype="0"
+    server=""
+    proxy=""
+    port=""
+    mmsc=""
+    mmsproxy=""
+    mmsport=""
+    type="ims"
+    protocol="IPV4V6"
+    defaultflag="2"
+    preferapp="" />
+
+<!--
+<apn carrier="ATT Broadband"
+    mcc="310"
+    mnc="410"
+    apn="broadband"
+    user=""
+    password=""
+    authtype="0"
+    server=""
+    proxy=""
+    port=""
+    mmsc=""
+    mmsproxy=""
+    mmsport=""
+    type="entitlement"
+    protocol="IP"
+    preferapp="" />
+-->
+
+<apn carrier="Emergency"
+    mcc="310"
+    mnc="410"
+    apn="sos"
+    user=""
+    password=""
+    authtype="0"
+    server=""
+    proxy=""
+    port=""
+    mmsc=""
+    mmsproxy=""
+    mmsport=""
+    type="emergency"
+    protocol="IPV4V6"
+    defaultflag="2"
+    preferapp="" />
+
+
+<!-- AIO US -->
+<apn carrier="ATT Phone"
+    mcc="310"
+    mnc="150"
+    apn="phone"
+    user=""
+    password=""
+    authtype="0"
+    server=""
+    proxy=""
+    port=""
+    mmsc="http://mmsc.mobile.att.net"
+    mmsproxy="proxy.mobile.att.net"
+    mmsport="80"
+    type="default,mms,supl,hipri,fota"
+    protocol="IP"
+    preferapp="" />
+
+<!-- LG Testbed  -->
+<apn carrier="LGE DEFAULT"
+    mcc="450"
+    mnc="00"
+    apn="lte"
+    user="lge"
+    password="lge"
+    authtype="1"
+    server=""
+    proxy=""
+    port=""
+    mmsc="http://203.229.247.19/mm1"
+    mmsproxy="203.229.247.28"
+    mmsport="8000"
+    type="default,mms,supl,hipri,fota"
+    defaultflag="0"
+    preferapp="" />
+
+
+</apns>

--- a/d850/proprietary/etc/gps.conf
+++ b/d850/proprietary/etc/gps.conf
@@ -1,0 +1,94 @@
+#Uncommenting these urls would only enable
+#the power up auto injection and force injection(test case).
+XTRA_SERVER_1=http://xtra1.gpsonextra.net/xtra2.bin
+XTRA_SERVER_2=http://xtra2.gpsonextra.net/xtra2.bin
+XTRA_SERVER_3=http://xtra3.gpsonextra.net/xtra2.bin
+
+# Error Estimate
+# _SET = 1
+# _CLEAR = 0
+ERR_ESTIMATE=0
+
+#Test
+# NTP_SERVER=time.gpsonextra.net
+#Asia
+# NTP_SERVER=asia.pool.ntp.org
+#Europe
+# NTP_SERVER=europe.pool.ntp.org
+#North America
+NTP_SERVER=north-america.pool.ntp.org
+#Korea
+# NTP_SERVER=0.kr.pool.ntp.org
+#JP
+# NTP_SERVER=3.jp.pool.ntp.org
+
+# DEBUG LEVELS: 0 - none, 1 - Error, 2 - Warning, 3 - Info
+#               4 - Debug, 5 - Verbose
+# If DEBUG_LEVEL is commented, Android's logging levels will be used
+DEBUG_LEVEL = 3
+
+# Intermediate position report, 1=enable, 0=disable
+INTERMEDIATE_POS=0
+
+# supl version 1.0
+#SUPL_VER=0x10000
+# supl version 2.0
+SUPL_VER=0x20000
+
+# GPS Capabilities bit mask
+# SCHEDULING = 0x01
+# MSB = 0x02
+# MSA = 0x04
+# ON_DEMAND_TIME = 0x10
+# GEOFENCE = 0x20
+# default = ON_DEMAND_TIME | MSA | MSB | SCHEDULING | GEOFENCE
+CAPABILITIES=0x33
+
+# Accuracy threshold for intermediate positions
+# less accurate positions are ignored, 0 for passing all positions
+# ACCURACY_THRES=5000
+
+################################
+##### AGPS server settings #####
+################################
+
+# FOR SUPL SUPPORT, set the following
+# SUPL_HOST=supl.host.com or IP
+# SUPL_PORT=1234
+SUPL_HOST=
+SUPL_PORT=7275
+
+# FOR C2K PDE SUPPORT, set the following
+# C2K_HOST=c2k.pde.com or IP
+# C2K_PORT=1234
+
+####################################
+#  LTE Positioning Profile Settings
+####################################
+# 0: Enable RRLP on LTE(Default)
+# 1: Enable LPP_User_Plane on LTE
+# 2: Enable LPP_Control_Plane
+# 3: Enable both LPP_User_Plane and LPP_Control_Plane
+LPP_PROFILE = 3
+
+################################
+# EXTRA SETTINGS
+################################
+# NMEA provider (1=Modem Processor, 0=Application Processor)
+#NMEA_PROVIDER=0
+NMEA_PROVIDER=1
+
+##################################################
+# Select Positioning Protocol on A-GLONASS system
+##################################################
+# 0x1: RRC CPlane
+# 0x2: RRLP UPlane
+# 0x4: LLP Uplane
+A_GLONASS_POS_PROTOCOL_SELECT = 0x7
+
+################################
+# LGE EXTRA SETTINGS
+################################
+VENDOR=ATT
+LGE_TLS_MODE=5
+LGE_GPS_POSITION_MODE=1


### PR DESCRIPTION
Use stock AT&T G3 (d850) apns-conf.xml.
CM APN file causes issues with MMS.
Adding new ATT APN causes conflicts with existing APN entries.
Deleting existing APNs in apns-conf.xml may cuase issues with other devices.

Change-Id: I1f0c10476d2082cf502b30fd51d512c807021001
