### PR TITLE
g2: remove qcom location app.

### DIFF
--- a/g2-common/g2-common-vendor.mk
+++ b/g2-common/g2-common-vendor.mk
@@ -23,10 +23,6 @@ PRODUCT_PACKAGES += \
     qcrilhook
 
 PRODUCT_PACKAGES += \
-    com.qualcomm.location \
-    com.qualcomm.services.location
-
-PRODUCT_PACKAGES += \
     libtime_genoff \
     libTimeService
 


### PR DESCRIPTION
fix the FC message on latest CMs.
