### PR TITLE
bullhead: flag dmservice apk as 32bit module

### DIFF
--- a/bullhead/Android.mk
+++ b/bullhead/Android.mk
@@ -147,6 +147,7 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := DMService
 LOCAL_MODULE_OWNER := lge
 LOCAL_SRC_FILES := proprietary/priv-app/DMService/DMService.apk
+LOCAL_MULTILIB := 32
 LOCAL_CERTIFICATE := platform
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_CLASS := APPS


### PR DESCRIPTION
This is the fix for dmservice crashing when using project fi app.
It prevents the 32bit dmservice apk from being incorrectly treated as a 64bit apk during the dex-preopt process.

https://jira.cyanogenmod.org/browse/CYAN-8004
