### PR TITLE
d852: add libqmi_client_helper.so to the d852-vendor.mk

### DIFF
--- a/d852/d852-vendor.mk
+++ b/d852/d852-vendor.mk
@@ -58,6 +58,7 @@ PRODUCT_COPY_FILES += \
     vendor/lge/d852/proprietary/vendor/lib/libqdp.so:system/vendor/lib/libqdp.so \
     vendor/lge/d852/proprietary/vendor/lib/libqmi.so:system/vendor/lib/libqmi.so \
     vendor/lge/d852/proprietary/vendor/lib/libqmi_cci.so:system/vendor/lib/libqmi_cci.so \
+    vendor/lge/d852/proprietary/vendor/lib/libqmi_client_helper.so:system/vendor/lib/libqmi_client_helper.so \
     vendor/lge/d852/proprietary/vendor/lib/libqmi_client_qmux.so:system/vendor/lib/libqmi_client_qmux.so \
     vendor/lge/d852/proprietary/vendor/lib/libqmi_common_so.so:system/vendor/lib/libqmi_common_so.so \
     vendor/lge/d852/proprietary/vendor/lib/libqmi_csi.so:system/vendor/lib/libqmi_csi.so \


### PR DESCRIPTION
The libqmi_client_helper.so proprietary file is missing from d852-vendor.mk.